### PR TITLE
Fixed email syntax in all php file header doc blocks

### DIFF
--- a/examples/SwissPaymentSlipTcpdf_Orange_Slip.php
+++ b/examples/SwissPaymentSlipTcpdf_Orange_Slip.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/

--- a/examples/SwissPaymentSlipTcpdf_Red_Slip.php
+++ b/examples/SwissPaymentSlipTcpdf_Red_Slip.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/

--- a/examples/SwissPaymentSlipTcpdf_Thousand_Slips.php
+++ b/examples/SwissPaymentSlipTcpdf_Thousand_Slips.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/

--- a/examples/index.php
+++ b/examples/index.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/

--- a/src/PaymentSlipTcpdf.php
+++ b/src/PaymentSlipTcpdf.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/

--- a/tests/PaymentSlipTcpdfTest.php
+++ b/tests/PaymentSlipTcpdfTest.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  * @copyright 2012-2015 Some nice Swiss guys
- * @author Marc Würth ravage@bluewin.ch
+ * @author Marc Würth <ravage@bluewin.ch>
  * @author Manuel Reinhard <manu@sprain.ch>
  * @author Peter Siska <pesche@gridonic.ch>
  * @link https://github.com/ravage84/SwissPaymentSlipTcpdf/


### PR DESCRIPTION
@ravage84
Found the the issue while working on [SwissPaymentSlipFpdf](https://github.com/ravage84/SwissPaymentSlipFpdf)
